### PR TITLE
jfrog link no longer valid, fallback to slower one

### DIFF
--- a/third_party/rules_boost.patch
+++ b/third_party/rules_boost.patch
@@ -208,3 +208,14 @@ diff -u -N -r a/rules_boost/BUILD.zstd b/rules_boost/BUILD.zstd
 +        "@platforms//os:windows",
      ],
  )
+diff -u -N -r a/rules_boost/boost/boost.bzl b/rules_boost/boost/boost.bzl
+--- boost/boost.bzl     2021-07-17 11:53:36.000000000 +0800
++++ boost/boost.bzl     2024-12-11 00:14:32.364215959 +0800
+@@ -215,7 +215,7 @@
+         sha256 = "7bd7ddceec1a1dfdcbdb3e609b60d01739c38390a5f956385a12f3122049f0ca",
+         strip_prefix = "boost_1_76_0",
+         urls = [
+-            "https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz",
++            "https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.gz",
+         ],
+     )

--- a/third_party/rules_boost.patch
+++ b/third_party/rules_boost.patch
@@ -209,8 +209,8 @@ diff -u -N -r a/rules_boost/BUILD.zstd b/rules_boost/BUILD.zstd
      ],
  )
 diff -u -N -r a/rules_boost/boost/boost.bzl b/rules_boost/boost/boost.bzl
---- boost/boost.bzl     2021-07-17 11:53:36.000000000 +0800
-+++ boost/boost.bzl     2024-12-11 00:14:32.364215959 +0800
+--- boost/boost.bzl 2021-07-17 11:53:36.000000000 +0800
++++ boost/boost.bzl 2024-12-11 00:14:32.364215959 +0800
 @@ -215,7 +215,7 @@
          sha256 = "7bd7ddceec1a1dfdcbdb3e609b60d01739c38390a5f956385a12f3122049f0ca",
          strip_prefix = "boost_1_76_0",


### PR DESCRIPTION
as titled, pls ignore it if https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz still works well.